### PR TITLE
Improve homebrew support: use absolute install path in corelib.pro

### DIFF
--- a/src/corelib/corelib.pro
+++ b/src/corelib/corelib.pro
@@ -117,20 +117,14 @@ defineTest(pathIsAbsolute) {
 ##### This requires fixing, so that the feature system works with cmake as well
 CMAKE_DISABLED_FEATURES = $$join(QT_DISABLED_FEATURES, "$$escape_expand(\\n)    ")
 
-CMAKE_HOST_DATA_DIR = $$cmakeRelativePath($$[QT_HOST_DATA/src], $$[QT_INSTALL_PREFIX])
-pathIsAbsolute($$CMAKE_HOST_DATA_DIR) {
-    CMAKE_HOST_DATA_DIR = $$[QT_HOST_DATA/src]/
+    CMAKE_HOST_DATA_DIR = $$[QT_INSTALL_PREFIX]/
     CMAKE_HOST_DATA_DIR_IS_ABSOLUTE = True
-}
 
 cmake_extras_mkspec_dir.input = $$PWD/Qt5CoreConfigExtrasMkspecDir.cmake.in
 cmake_extras_mkspec_dir.output = $$DESTDIR/cmake/Qt5Core/Qt5CoreConfigExtrasMkspecDir.cmake
 
-CMAKE_INSTALL_DATA_DIR = $$cmakeRelativePath($$[QT_HOST_DATA], $$[QT_INSTALL_PREFIX])
-pathIsAbsolute($$CMAKE_INSTALL_DATA_DIR) {
-    CMAKE_INSTALL_DATA_DIR = $$[QT_HOST_DATA]/
+    CMAKE_INSTALL_DATA_DIR = $$[QT_INSTALL_PREFIX]/
     CMAKE_INSTALL_DATA_DIR_IS_ABSOLUTE = True
-}
 
 cmake_extras_mkspec_dir_for_install.input = $$PWD/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
 cmake_extras_mkspec_dir_for_install.output = $$DESTDIR/cmake/install/Qt5Core/Qt5CoreConfigExtrasMkspecDir.cmake


### PR DESCRIPTION
The [homebrew project](https://brew.sh) is a very popular way for users to install Qt5, with [several hundred thousand installations in the past year](https://brew.sh/analytics/install/). Homebrew typically installs each software package to an isolated subfolder in `/usr/local/Cellar` and if possible links some of those installed files to `/usr/local` (the contents of bin, include, lib, share, and a limited number of others). It is much easier for developers building against Qt5 to have software linked to `/usr/local` so they don't have to set extra environment variables. Currently brew does not link the `mkspecs` folder or the `plugins` folder to `/usr/local`, which causes a cmake `find_package(Qt5Core)` to fail (as detailed in https://github.com/Homebrew/homebrew-core/issues/8392 ). I submitted a patch similar to this one to the homebrew maintainers as a potential fix, but they prefer patches to go upstream ( https://github.com/Homebrew/homebrew-core/issues/8392#issuecomment-269953594 ), so I've submitted this patch here to start a conversation.

It's probably not suitable in its current state since it reduces some relocatability. Would it be possible to expose a build option that could trigger this logic? This would greatly improve the experience of developers using Qt5 on macOS. I can work to make this patch suitable if you give some guidance on how to implement it, since I'm not very familiar with the Qt build system.

Thanks for your time.