### PR TITLE
Fix build on FreeBSD/powerpc64

### DIFF
--- a/src/corelib/configure.json
+++ b/src/corelib/configure.json
@@ -133,6 +133,7 @@
         "libatomic": {
             "label": "64 bit atomics",
             "test": {
+                "include": [ "atomic", "cstdint" ],
                 "tail": [
                     "void test(volatile std::atomic<std::int64_t> &a)",
                     "{",
@@ -151,7 +152,6 @@
                 ],
                 "qmake": "CONFIG += c++11"
             },
-            "headers": [ "atomic", "cstdint" ],
             "sources": [
                 "",
                 "-latomic"


### PR DESCRIPTION
https://github.com/qt/qtbase/commit/e80bf655e922e9864f8843b5e7bbb47019a6d95a#diff-7b8fcc510868f4571a6af4f5ce48a426 broke test for 64 bit atomics on FreeBSD/powerpc64. Revert to the old behaviour to fix this test and thus fix build.