### PR TITLE
configure qtbase with -D QT_KEYPAD_NAVIGATION  undefined reference

### DIFF
--- a/src/widgets/widgets/qlineedit.cpp
+++ b/src/widgets/widgets/qlineedit.cpp
@@ -1479,10 +1479,10 @@ bool QLineEdit::event(QEvent * e)
         if (e->type() == QEvent::EnterEditFocus) {
             end(false);
             d->setCursorVisible(true);
-            d->control->setCursorBlinkEnabled(true);
+            d->control->setBlinkingCursorEnabled(true);
         } else if (e->type() == QEvent::LeaveEditFocus) {
             d->setCursorVisible(false);
-            d->control->setCursorBlinkEnabled(false);
+            d->control->setBlinkingCursorEnabled(false);
             if (d->control->hasAcceptableInput() || d->control->fixup())
                 emit editingFinished();
         }

--- a/src/widgets/widgets/qwidgettextcontrol.cpp
+++ b/src/widgets/widgets/qwidgettextcontrol.cpp
@@ -2223,9 +2223,9 @@ void QWidgetTextControlPrivate::editFocusEvent(QEvent *e)
             selectionChanged();
             repaintOldAndNewSelection(oldSelection);
 
-            setBlinkingCursorEnabled(true);
+            setCursorVisible(true);
         } else
-            setBlinkingCursorEnabled(false);
+            setCursorVisible(false);
     }
 
     hasEditFocus = e->type() == QEvent::EnterEditFocus;


### PR DESCRIPTION
configure qtbase with -D QT_KEYPAD_NAVIGATION not working => undefined reference.

adapted to use existing functions