### PR TITLE
QTBUG-79372: Fixed zero progress after http uploading

### DIFF
--- a/src/network/access/qnetworkreplyhttpimpl.cpp
+++ b/src/network/access/qnetworkreplyhttpimpl.cpp
@@ -2103,6 +2103,7 @@ void QNetworkReplyHttpImplPrivate::emitReplyUploadProgress(qint64 bytesSent, qin
     if (isFinished)
         return;
 
+    bytesUploaded = bytesSent;
     if (!emitAllUploadProgressSignals) {
         //choke signal emissions, except the first and last signals which are unconditional
         if (uploadProgressSignalChoke.isValid()) {


### PR DESCRIPTION
The bytesUploaded variable does not change the value during the upload process, so when the download is completed in the QNetworkReply :: uploadProgress call, the sentBytes and totalBytes parameters are set to 0.