### PR TITLE
add limit condition to function setDirtyCursor()

### DIFF
--- a/src/plugins/platforms/vnc/qvncclient.h
+++ b/src/plugins/platforms/vnc/qvncclient.h
@@ -69,7 +69,7 @@ public:
     QVncServer *server() const { return m_server; }
 
     void setDirty(const QRegion &region);
-    void setDirtyCursor() { m_dirtyCursor = true; scheduleUpdate(); }
+    void setDirtyCursor() { if( m_state != Connected ) return; m_dirtyCursor = true; scheduleUpdate(); }
     QRegion dirtyRegion() const { return m_dirtyRegion; }
     inline bool isConnected() const { return m_state == Connected; }
 


### PR DESCRIPTION
avoid segment fault when a vncclient  disconnect while others are keep connecting.