### PR TITLE
Improve QTextDocumentPrivate  cursor performance

### DIFF
--- a/src/gui/text/qtextdocument_p.cpp
+++ b/src/gui/text/qtextdocument_p.cpp
@@ -243,7 +243,7 @@ void QTextDocumentPrivate::clear()
         curs->adjusted_anchor = 0;
     }
 
-    QList<QTextCursorPrivate *>oldCursors = cursors;
+    QSet<QTextCursorPrivate *> oldCursors = cursors;
     QT_TRY{
         cursors.clear();
 

--- a/src/gui/text/qtextdocument_p.h
+++ b/src/gui/text/qtextdocument_p.h
@@ -277,8 +277,8 @@ private:
 public:
     void documentChange(int from, int length);
 
-    inline void addCursor(QTextCursorPrivate *c) { cursors.append(c); }
-    inline void removeCursor(QTextCursorPrivate *c) { cursors.removeAll(c); }
+    inline void addCursor(QTextCursorPrivate *c) { cursors.insert(c); }
+    inline void removeCursor(QTextCursorPrivate *c) { cursors.remove(c); }
 
     QTextFrame *frameAt(int pos) const;
     QTextFrame *rootFrame() const;
@@ -330,7 +330,7 @@ private:
     BlockMap blocks;
     int initialBlockCharFormatIndex;
 
-    QList<QTextCursorPrivate *> cursors;
+    QSet<QTextCursorPrivate *> cursors;
     QMap<int, QTextObject *> objects;
     QMap<QUrl, QVariant> resources;
     QMap<QUrl, QVariant> cachedResources;


### PR DESCRIPTION
The cursors in QTextDocumentPrivate are held in a QList.
This becomes a serious performance problem with lots of extra selections due to a call to QTextDocumentPrivate::removeCursor() from the QTextCursor destructor.

Given the following test program:

>QPlainTextEdit *editor = ...
std::list< QTextCursor> list;
  for(int i = 0; i < 100000; ++i) {
    QTextCursor c(editor->document());
    c.setPosition(std::rand()%100);
    list.push_front(c);
  }
   list.clear(); // <-- clear calls hangs for 3+ seconds due to time spent in QTextDocumentPrivate::removeCursor() dues to QList::removeAll() call
  
Note the push_front because it exacerbates the issue because the entire list will be traversed.

The change submitted changes the structure to a set; removing the issue.
In theory, this limits that a cursors cannot be in the structure twice, but this neither happens nor would it make sense.

