### PR TITLE
qDeleteAll: Use const iterators

### DIFF
--- a/src/corelib/tools/qalgorithms.h
+++ b/src/corelib/tools/qalgorithms.h
@@ -325,7 +325,7 @@ Q_OUTOFLINE_TEMPLATE void qDeleteAll(ForwardIterator begin, ForwardIterator end)
 template <typename Container>
 inline void qDeleteAll(const Container &c)
 {
-    qDeleteAll(c.begin(), c.end());
+    qDeleteAll(c.cbegin(), c.cend());
 }
 
 /*


### PR DESCRIPTION
@thiagomacieira Hey Thiago, as far as I know Qt containers detach when calls made to begin() and end() functions and this leads to a deep copy. Besides that, we should be able to delete C++ objects with const iterators; then why not use const iterators instead? What do you think?