### PR TITLE
qmimeprovider.cpp:649:18: error: invalid conversion

### DIFF
--- a/src/corelib/mimetypes/qmimeprovider.cpp
+++ b/src/corelib/mimetypes/qmimeprovider.cpp
@@ -647,7 +647,7 @@ QMimeXMLProvider::QMimeXMLProvider(QMimeDatabasePrivate *db, InternalDatabaseEnu
 #elif defined(MIME_DATABASE_IS_GZIP)
     std::unique_ptr<char []> uncompressed(new char[size]);
     z_stream zs = {};
-    zs.next_in = mimetype_database;
+    zs.next_in = const_cast<Bytef *>(mimetype_database);
     zs.avail_in = sizeof(mimetype_database);
     zs.next_out = reinterpret_cast<Bytef *>(uncompressed.get());
     zs.avail_out = size;


### PR DESCRIPTION
qt 5.15.0 tarball compilation fails with this error message (linux/gcc 8):
```
mimetypes/qmimeprovider.cpp: In constructor 'QMimeXMLProvider::QMimeXMLProvider(QMimeDatabasePrivate*, QMimeXMLProvider::InternalDatabaseEnum)':
mimetypes/qmimeprovider.cpp:649:18: error: invalid conversion from 'const unsigned char*' to 'Bytef*' {aka 'unsigned char*'} [-fpermissive]
     zs.next_in = mimetype_database;
                  ^~~~~~~~~~~~~~~~~
moc time/qcalendar.h
moc io/qfile.h
moc io/qbuffer.h
moc io/qfiledevice.h
moc io/qiodevice.h
moc io/qnoncontiguousbytedevice_p.h
moc io/qsavefile.h
moc io/qtemporaryfile.h
moc io/qstandardpaths.h
moc io/qfileselector.h
make[3]: *** [.obj/qmimeprovider.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory `/usr/local/src/qt-everywhere-src-5.15.0/qtbase/src/corelib'
make[2]: Leaving directory `/usr/local/src/qt-everywhere-src-5.15.0/qtbase/src'
make[2]: *** [sub-corelib-make_first] Error 2
make[1]: *** [sub-src-make_first] Error 2
make[1]: Leaving directory `/usr/local/src/qt-everywhere-src-5.15.0/qtbase'
make: *** [module-qtbase-make_first] Error 2
```