### PR TITLE
wasm/js: fix invalid restartCount reference

### DIFF
--- a/src/plugins/platforms/wasm/qtloader.js
+++ b/src/plugins/platforms/wasm/qtloader.js
@@ -242,7 +242,7 @@ function QtLoader(config)
     publicAPI.setFontDpi = setFontDpi;
     publicAPI.fontDpi = fontDpi;
 
-    restartCount = 0;
+    self.restartCount = 0;
 
     function fetchResource(filePath) {
         var fullPath = config.path + filePath;


### PR DESCRIPTION
The `restartCount` variable on line 245 is mutating global scope. The PR makes it consistent with the rest of the code (`self.restartCount`).

I noticed it after my app refused to build in a typical Webpack/Babel build environment.

An application built with this patch applied locally can be found here: https://avindra.github.io/#/ttt-plusplus

If it matters, I used [Emscripten 2.0.9](https://github.com/emscripten-core/emscripten/releases/tag/2.0.9) to build it.