### PR TITLE
Fix: Under dual screens, double dpi zooming, the borderless window window will drift when dragging; improve QScreen to get size errors under double zooming

### DIFF
--- a/src/gui/kernel/qhighdpiscaling_p.h
+++ b/src/gui/kernel/qhighdpiscaling_p.h
@@ -140,12 +140,12 @@ inline QVector2D scale(const QVector2D &value, qreal scaleFactor, QPointF /* ori
 
 inline QPointF scale(const QPointF &pos, qreal scaleFactor, QPointF origin = QPointF(0, 0))
 {
-     return (pos - origin) * scaleFactor + origin;
+     return (pos - origin) * scaleFactor + origin * scaleFactor;
 }
 
 inline QPoint scale(const QPoint &pos, qreal scaleFactor, QPoint origin = QPoint(0, 0))
 {
-     return (pos - origin) * scaleFactor + origin;
+     return (pos - origin) * scaleFactor + origin * scaleFactor;
 }
 
 inline QRect scale(const QRect &rect, qreal scaleFactor, QPoint origin = QPoint(0, 0))

--- a/src/gui/kernel/qscreen.cpp
+++ b/src/gui/kernel/qscreen.cpp
@@ -375,6 +375,11 @@ QSize QScreen::availableSize() const
 QRect QScreen::geometry() const
 {
     Q_D(const QScreen);
+
+    if (d->platformScreen){
+        return QHighDpi::fromNativePixels(d->platformScreen->geometry(), this);
+    }
+
     return d->geometry;
 }
 


### PR DESCRIPTION
…ndow will drift when dragging; improve QScreen to get size errors under double zooming