### PR TITLE
Fix QComboBox height when using a stylesheet

### DIFF
--- a/src/widgets/styles/qstylesheetstyle.cpp
+++ b/src/widgets/styles/qstylesheetstyle.cpp
@@ -5030,8 +5030,10 @@ QSize QStyleSheetStyle::sizeFromContents(ContentsType ct, const QStyleOption *op
                 }
             }
             if (rule.hasBox() || rule.hasBorder() || !rule.hasNativeBorder())
-                sz = rule.boxSize(sz);
-            return sz;
+                return rule.boxSize(sz);
+            sz = rule.baseStyleCanDraw() ? baseStyle()->sizeFromContents(ct, opt, sz, w)
+                                         : QWindowsStyle::sizeFromContents(ct, opt, sz, w);
+            return rule.boxSize(sz, Margin);
         }
         break;
 #endif // QT_CONFIG(spinbox)

--- a/src/widgets/styles/qstylesheetstyle.cpp
+++ b/src/widgets/styles/qstylesheetstyle.cpp
@@ -5029,11 +5029,12 @@ QSize QStyleSheetStyle::sizeFromContents(ContentsType ct, const QStyleOption *op
                     sz.rwidth() += defaultUpSize.width();
                 }
             }
-            if (rule.hasBox() || rule.hasBorder() || !rule.hasNativeBorder())
-                return rule.boxSize(sz);
-            sz = rule.baseStyleCanDraw() ? baseStyle()->sizeFromContents(ct, opt, sz, w)
-                                         : QWindowsStyle::sizeFromContents(ct, opt, sz, w);
-            return rule.boxSize(sz, Margin);
+            if (rule.hasBox() || !rule.hasNativeBorder())
+                sz = rule.boxSize(sz);
+            else
+                sz = rule.baseStyleCanDraw() ? baseStyle()->sizeFromContents(ct, opt, sz, w)
+                                             : QWindowsStyle::sizeFromContents(ct, opt, sz, w);
+            return rule.boxSize(sz);
         }
         break;
 #endif // QT_CONFIG(spinbox)


### PR DESCRIPTION
This is a fix for https://bugreports.qt.io/browse/QTBUG-80814
Fix is inspired from the Qt4 code
"A QSpinBox/QDoubleSpinbox has a different (smaller) size as soon as we set a stylesheet on one of its parents."
Even if we do not set any style for spinboxes

![image](https://user-images.githubusercontent.com/182520/102644852-ce144480-4161-11eb-8342-46ec37d96584.png)
![image](https://user-images.githubusercontent.com/182520/102644879-d9677000-4161-11eb-839f-caf92f13cb51.png)
