### PR TITLE
Ex:SimpleTreeModel: make argument name consistent

### DIFF
--- a/examples/widgets/itemviews/simpletreemodel/treeitem.h
+++ b/examples/widgets/itemviews/simpletreemodel/treeitem.h
@@ -61,7 +61,7 @@ public:
     explicit TreeItem(const QList<QVariant> &data, TreeItem *parentItem = nullptr);
     ~TreeItem();
 
-    void appendChild(TreeItem *child);
+    void appendChild(TreeItem *item);
 
     TreeItem *child(int row);
     int childCount() const;


### PR DESCRIPTION
In the header of qtbase/examples/widgets/itemviews/simpletreemodel/treeitem.h, 
the argument name of `appendChild` was inconsistent with its implementation (treeitem.cpp).

This PR renames the respective argument to the one used in the implementation.

If this inconsistency was intentional, go ahead closing the request.