### PR TITLE
Avoid cyclic dependency between plugin and module *Config.cmake files

### DIFF
--- a/cmake/QtPlugins.cmake.in
+++ b/cmake/QtPlugins.cmake.in
@@ -137,4 +137,10 @@ if(NOT @BUILD_SHARED_LIBS@)
         target_sources(${_module_target} INTERFACE
                        "$<${_plugin_condition}:${_generated_qt_plugin_file_name}>")
     endforeach()
+
+    set_target_properties(${_module_target} PROPERTIES __qt_internal_plugins_added TRUE)
+endfunction()
+
+if(NOT @BUILD_SHARED_LIBS@ AND NOT QT_NO_CREATE_TARGETS)
+    __qt_internal_add_static_plugins_once()
 endif()


### PR DESCRIPTION
In static per-repo builds, we have a mix of targets provided by
packages and targets provided by the main build. For the builds that
create the packages, we must avoid adding a dependency for the main
module library target on its associated plugin targets or else the
package config files end up with a cyclic dependency that cannot be
resolved when something tries to consume them. This only happens for
static builds because we have been attaching a linking relationship
to the main module library that isn't really a true dependency, we
attached it only for convenience of things linking to that module
library.

To preserve that convenience linking without breaking the config
packages, we use the QT_NO_CREATE_TARGETS condition to prevent CMake
seeing that relationship when generating the *Config.cmake files.
Creating these relationships will be delayed until the plugin's
*Config.cmake file is loaded, at which point it will add itself to
the main module library's imported target INTERFACE (this was already
done before, we just now rely solely on that).

Task-number: QTBUG-90819
Pick-to: 6.1
Change-Id: Id725742182bcda64841be84fe1650bafb9151bb1
Reviewed-by: Joerg Bornemann <joerg.bornemann@qt.io>