### PR TITLE
qtbase: remove std::remove_cv after using std::remove_pointer

### DIFF
--- a/src/corelib/kernel/qobject.h
+++ b/src/corelib/kernel/qobject.h
@@ -164,14 +164,14 @@ public:
     template<typename T>
     inline T findChild(const QString &aName = QString(), Qt::FindChildOptions options = Qt::FindChildrenRecursively) const
     {
-        typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type ObjType;
+        typedef typename std::remove_pointer<T>::type ObjType;
         return static_cast<T>(qt_qFindChild_helper(this, aName, ObjType::staticMetaObject, options));
     }
 
     template<typename T>
     inline QList<T> findChildren(const QString &aName, Qt::FindChildOptions options = Qt::FindChildrenRecursively) const
     {
-        typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type ObjType;
+        typedef typename std::remove_pointer<T>::type ObjType;
         QList<T> list;
         qt_qFindChildren_helper(this, aName, ObjType::staticMetaObject,
                                 reinterpret_cast<QList<void *> *>(&list), options);
@@ -181,7 +181,7 @@ public:
     template<typename T>
     QList<T> findChildren(Qt::FindChildOptions options = Qt::FindChildrenRecursively) const
     {
-        typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type ObjType;
+        typedef typename std::remove_pointer<T>::type ObjType;
         QList<T> list;
         qt_qFindChildren_helper(this, ObjType::staticMetaObject,
                                 reinterpret_cast<QList<void *> *>(&list), options);
@@ -192,7 +192,7 @@ public:
     template<typename T>
     inline QList<T> findChildren(const QRegularExpression &re, Qt::FindChildOptions options = Qt::FindChildrenRecursively) const
     {
-        typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type ObjType;
+        typedef typename std::remove_pointer<T>::type ObjType;
         QList<T> list;
         qt_qFindChildren_helper(this, re, ObjType::staticMetaObject,
                                 reinterpret_cast<QList<void *> *>(&list), options);
@@ -465,7 +465,7 @@ inline QMetaObject::Connection QObject::connect(const QObject *asender, const ch
 template <class T>
 inline T qobject_cast(QObject *object)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type ObjType;
+    typedef typename std::remove_pointer<T>::type ObjType;
     static_assert(QtPrivate::HasQ_OBJECT_Macro<ObjType>::Value,
                     "qobject_cast requires the type to have a Q_OBJECT macro");
     return static_cast<T>(ObjType::staticMetaObject.cast(object));
@@ -474,7 +474,7 @@ inline T qobject_cast(QObject *object)
 template <class T>
 inline T qobject_cast(const QObject *object)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type ObjType;
+    typedef typename std::remove_pointer<T>::type ObjType;
     static_assert(QtPrivate::HasQ_OBJECT_Macro<ObjType>::Value,
                       "qobject_cast requires the type to have a Q_OBJECT macro");
     return static_cast<T>(ObjType::staticMetaObject.cast(object));

--- a/src/widgets/graphicsview/qgraphicsitem.h
+++ b/src/widgets/graphicsview/qgraphicsitem.h
@@ -1010,14 +1010,14 @@ private:
 
 template <class T> inline T qgraphicsitem_cast(QGraphicsItem *item)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type Item;
+    typedef typename std::remove_pointer<T>::type Item;
     return int(Item::Type) == int(QGraphicsItem::Type)
         || (item && int(Item::Type) == item->type()) ? static_cast<T>(item) : 0;
 }
 
 template <class T> inline T qgraphicsitem_cast(const QGraphicsItem *item)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type Item;
+    typedef typename std::remove_pointer<T>::type Item;
     return int(Item::Type) == int(QGraphicsItem::Type)
         || (item && int(Item::Type) == item->type()) ? static_cast<T>(item) : 0;
 }

--- a/src/widgets/styles/qstyleoption.h
+++ b/src/widgets/styles/qstyleoption.h
@@ -699,7 +699,7 @@ protected:
 template <typename T>
 T qstyleoption_cast(const QStyleOption *opt)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type Opt;
+    typedef typename std::remove_pointer<T>::type Opt;
     if (opt && opt->version >= Opt::Version && (opt->type == Opt::Type
         || int(Opt::Type) == QStyleOption::SO_Default
         || (int(Opt::Type) == QStyleOption::SO_Complex
@@ -711,7 +711,7 @@ T qstyleoption_cast(const QStyleOption *opt)
 template <typename T>
 T qstyleoption_cast(QStyleOption *opt)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type Opt;
+    typedef typename std::remove_pointer<T>::type Opt;
     if (opt && opt->version >= Opt::Version && (opt->type == Opt::Type
         || int(Opt::Type) == QStyleOption::SO_Default
         || (int(Opt::Type) == QStyleOption::SO_Complex
@@ -762,7 +762,7 @@ public:
 template <typename T>
 T qstyleoption_cast(const QStyleHintReturn *hint)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type Opt;
+    typedef typename std::remove_pointer<T>::type Opt;
     if (hint && hint->version <= Opt::Version &&
         (hint->type == Opt::Type || int(Opt::Type) == QStyleHintReturn::SH_Default))
         return static_cast<T>(hint);
@@ -772,7 +772,7 @@ T qstyleoption_cast(const QStyleHintReturn *hint)
 template <typename T>
 T qstyleoption_cast(QStyleHintReturn *hint)
 {
-    typedef typename std::remove_cv<typename std::remove_pointer<T>::type>::type Opt;
+    typedef typename std::remove_pointer<T>::type Opt;
     if (hint && hint->version <= Opt::Version &&
         (hint->type == Opt::Type || int(Opt::Type) == QStyleHintReturn::SH_Default))
         return static_cast<T>(hint);


### PR DESCRIPTION
std::remove_pointer had removed cv properties