### PR TITLE
Do not specify O_CLOEXEC when opening (qt_safe_open does it)

### DIFF
--- a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmdevice.cpp
+++ b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmdevice.cpp
@@ -65,7 +65,7 @@ bool QEglFSKmsGbmDevice::open()
     Q_ASSERT(fd() == -1);
     Q_ASSERT(m_gbm_device == nullptr);
 
-    int fd = qt_safe_open(devicePath().toLocal8Bit().constData(), O_RDWR | O_CLOEXEC);
+    int fd = qt_safe_open(devicePath().toLocal8Bit().constData(), O_RDWR);
     if (fd == -1) {
         qErrnoWarning("Could not open DRM device %s", qPrintable(devicePath()));
         return false;

--- a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_vsp2/qeglfskmsvsp2device.cpp
+++ b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_vsp2/qeglfskmsvsp2device.cpp
@@ -61,7 +61,7 @@ bool QEglFSKmsVsp2Device::open()
     Q_ASSERT(fd() == -1);
     Q_ASSERT(m_gbm_device == nullptr);
 
-    int fd = qt_safe_open(devicePath().toLocal8Bit().constData(), O_RDWR | O_CLOEXEC);
+    int fd = qt_safe_open(devicePath().toLocal8Bit().constData(), O_RDWR);
     if (fd == -1) {
         qErrnoWarning("Could not open DRM device %s", qPrintable(devicePath()));
         return false;

--- a/src/plugins/platforms/linuxfb/qlinuxfbdrmscreen.cpp
+++ b/src/plugins/platforms/linuxfb/qlinuxfbdrmscreen.cpp
@@ -125,7 +125,7 @@ QLinuxFbDevice::QLinuxFbDevice(QKmsScreenConfig *screenConfig)
 
 bool QLinuxFbDevice::open()
 {
-    int fd = qt_safe_open(devicePath().toLocal8Bit().constData(), O_RDWR | O_CLOEXEC);
+    int fd = qt_safe_open(devicePath().toLocal8Bit().constData(), O_RDWR);
     if (fd == -1) {
         qErrnoWarning("Could not open DRM device %s", qPrintable(devicePath()));
         return false;


### PR DESCRIPTION
For systems without O_CLOEXEC, no need to specify and this fixes compile
issues on Solaris 10.

qeglfskmsgbmdevice.cpp only required but no need to set it as it is
managed by qt_safe_open anyway.