### PR TITLE
qmake: Teach escapeFilePath to escape quotes

### DIFF
--- a/qmake/generators/unix/unixmake.cpp
+++ b/qmake/generators/unix/unixmake.cpp
@@ -767,7 +767,9 @@ UnixMakefileGenerator::escapeFilePath(const QString &path) const
     QString ret = path;
     if(!ret.isEmpty()) {
         ret.replace(QLatin1Char(' '), QLatin1String("\\ "))
-           .replace(QLatin1Char('\t'), QLatin1String("\\\t"));
+           .replace(QLatin1Char('\t'), QLatin1String("\\\t"))
+           .replace(QLatin1Char('\''), QLatin1String("\\'"))
+           .replace(QLatin1Char('"'), QLatin1String("\\\""));
         debug_msg(2, "EscapeFilePath: %s -> %s", path.toLatin1().constData(), ret.toLatin1().constData());
     }
     return ret;


### PR DESCRIPTION
Otherwise, Make is unhappy. For example:
```
13:42:49: Starting: "/usr/bin/make" clean -j8
/Users/alice/Qt/5.15.7/clang_64/bin/qmake -o Makefile ../Alice's\ Project.pro
/bin/sh: -c: line 0: unexpected EOF while looking for matching `''
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** [Makefile] Error 2
13:42:49: The process "/usr/bin/make" exited with code 2.
```