### PR TITLE
Note special case return

### DIFF
--- a/src/corelib/io/qfileinfo.cpp
+++ b/src/corelib/io/qfileinfo.cpp
@@ -1091,6 +1091,8 @@ bool QFileInfo::isBundle() const
 
     \note If the symlink points to a non existing file, exists() returns
      false.
+    \note If this QFileInfo object is given a path ending in a slash, isSymLink()
+     returns false.
 
     \sa isFile(), isDir(), symLinkTarget()
 */


### PR DESCRIPTION
If this QFileInfo object is given a path ending in a slash, isSymLink() returns false.

Fixes: QTBUG-100029
Change-Id: If1b94e7b6f477b5bdbf1b2548f13ea6958ea578a