### PR TITLE
xcb: Improve the logic of updateScreen_monitor

### DIFF
--- a/src/plugins/platforms/xcb/qxcbconnection_screens.cpp
+++ b/src/plugins/platforms/xcb/qxcbconnection_screens.cpp
@@ -259,6 +259,13 @@ void QXcbConnection::updateScreen_monitor(QXcbScreen *screen, xcb_randr_monitor_
         screen->virtualDesktop()->setPrimaryScreen(screen);
         QWindowSystemInterface::handlePrimaryScreenChanged(screen);
     }
+    else
+    {
+        m_screens.removeOne(screen);
+        m_screens.append(screen);
+        screen->virtualDesktop()->removeScreen(screen);
+        screen->virtualDesktop()->addScreen(screen);
+    }
     qCDebug(lcQpaScreen) << "updateScreen_monitor: update" << screen << "(Primary:" << screen->isPrimary() << ")";
 }
 

--- a/src/plugins/platforms/xcb/qxcbscreen.cpp
+++ b/src/plugins/platforms/xcb/qxcbscreen.cpp
@@ -598,6 +598,7 @@ void QXcbScreen::setMonitor(xcb_randr_monitor_info_t *monitorInfo, xcb_timestamp
     m_crtcs.clear();
     m_output = XCB_NONE;
     m_crtc = XCB_NONE;
+    m_singlescreen = false;
 
     if (!monitorInfo) {
         m_monitor = nullptr;


### PR DESCRIPTION
1.  correctly update the state of m_singlescreen
2.  keep the primary screen at the head of the screen queue

Signed-off-by: wujiang <wujiang@kylinos.cn>