### PR TITLE
Fix wrong method in qmultimap snippet

### DIFF
--- a/src/corelib/doc/snippets/code/src_corelib_tools_qmultimap.cpp
+++ b/src/corelib/doc/snippets/code/src_corelib_tools_qmultimap.cpp
@@ -19,7 +19,7 @@ multimap.insert("c", -5);
 int num2 = multimap.value("a"); // 1
 int num3 = multimap.value("thirteen"); // not found; 0
 int num3 = 0;
-auto it = multimap.value("b");
+auto it = multimap.find("b");
 if (it != multimap.end()) {
     num3 = it.value();
 }


### PR DESCRIPTION
I think there was an error and it shouldn't compile. The call to `value(..)` doesn't make sense here, as it returns the last inserted `int`.