### PR TITLE
xcb: fix segmentation fault on destruction of QXcbConnection. 

### DIFF
--- a/src/plugins/platforms/xcb/qxcbconnection_screens.cpp
+++ b/src/plugins/platforms/xcb/qxcbconnection_screens.cpp
@@ -516,7 +516,9 @@ void QXcbConnection::initializeScreensFromMonitor(xcb_screen_iterator_t *it, int
                 old.removeAll(screen);
             }
         }
-        m_screens << screen;
+        if (!m_screens.contains(screen)) {
+            m_screens << screen;
+        }
         siblings << screen;
 
         // similar logic with QXcbConnection::initializeScreensFromOutput()


### PR DESCRIPTION
Since we updated from Qt 5.15 to Qt 6.3, we sometimes got the following segmentation fault when triggering a SIGTERM command towards an app using Qt.

```
[Current thread is 1 (Thread 0x7f84f6bbed80 (LWP 1331))]
#0  0x00007f84f7027eac in QPlatformScreen::screen() const () from /usr/lib64/libQt6Gui.so.6
#1  0x00007f84f704d889 in QWindowSystemInterface::handleScreenRemoved(QPlatformScreen*) () from /usr/lib64/libQt6Gui.so.6
#2  0x00007f84e8c4bc2c in QXcbConnection::~QXcbConnection() () from /usr/lib64/libQt6XcbQpa.so.6
#3  0x00007f84e8c4bda9 in QXcbConnection::~QXcbConnection() () from /usr/lib64/libQt6XcbQpa.so.6
#4  0x00007f84e8c6ac56 in QXcbIntegration::~QXcbIntegration() () from /usr/lib64/libQt6XcbQpa.so.6
#5  0x00007f84e8c6ad29 in QXcbIntegration::~QXcbIntegration() () from /usr/lib64/libQt6XcbQpa.so.6
#6  0x00007f84f6ff264b in QGuiApplicationPrivate::~QGuiApplicationPrivate() () from /usr/lib64/libQt6Gui.so.6
#7  0x00007f84f786b2b9 in QApplicationPrivate::~QApplicationPrivate() () from /usr/lib64/libQt6Widgets.so.6
```

The root cause lies in `QXcbConnection::initializeScreensFromMonitor`.
The `m_screens` variable gets appended with the screen, but the same screen was already appended by calling `createScreen_monitor` a few lines earlier.
