### PR TITLE
Don't let QWindowsXpNativeFileDialog::populateOpenFileName() operate …

### DIFF
--- a/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+++ b/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
@@ -1786,16 +1786,17 @@ void QWindowsXpNativeFileDialog::populateOpenFileName(OPENFILENAME *ofn, HWND ow
     int totalStringLength = 0;
     const QList<FilterSpec> specs =
         filterSpecs(m_options->nameFilters(), m_options->options() & QFileDialogOptions::HideNameFilterDetails, &totalStringLength);
-    const int size = specs.size();
-    auto *ptr = new wchar_t[totalStringLength + 2 * size + 1];
-    ofn->lpstrFilter = ptr;
-    for (const FilterSpec &spec : specs) {
-        ptr += spec.description.toWCharArray(ptr);
-        *ptr++ = 0;
-        ptr += spec.filter.toWCharArray(ptr);
-        *ptr++ = 0;
+    if (const int size = specs.size()) {
+        auto *ptr = new wchar_t[totalStringLength + 2 * size + 1];
+        ofn->lpstrFilter = ptr;
+        for (const FilterSpec &spec : specs) {
+            ptr += spec.description.toWCharArray(ptr);
+            *ptr++ = 0;
+            ptr += spec.filter.toWCharArray(ptr);
+            *ptr++ = 0;
+        }
+        *ptr = 0;
     }
-    *ptr = 0;
     const int nameFilterIndex = indexOfNameFilter(m_options->nameFilters(), m_data.selectedNameFilter());
     if (nameFilterIndex >= 0)
         ofn->nFilterIndex = nameFilterIndex + 1; // 1..n based.


### PR DESCRIPTION
…on uninitialized memory when faced with an empty filter list