### PR TITLE
Bugfix: Use__cpp_lib_three_way_comparison instead of __cpp_impl_three…

### DIFF
--- a/src/corelib/text/qanystringview.h
+++ b/src/corelib/text/qanystringview.h
@@ -8,7 +8,7 @@
 #include <QtCore/qstringview.h>
 #include <QtCore/qutf8stringview.h>
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 #include <compare>
 #endif
 #include <QtCore/q20type_traits.h>


### PR DESCRIPTION
…_way_comparison

Use correct feature test macro for <compare> include