### PR TITLE
QXcbConnection::getTimestamp: do not return stale timestamp

### DIFF
--- a/src/plugins/platforms/xcb/qxcbconnection.cpp
+++ b/src/plugins/platforms/xcb/qxcbconnection.cpp
@@ -815,7 +815,8 @@ xcb_timestamp_t QXcbConnection::getTimestamp()
             if (type != XCB_PROPERTY_NOTIFY)
                 return false;
             auto propertyNotify = reinterpret_cast<xcb_property_notify_event_t *>(event);
-            return propertyNotify->window == window && propertyNotify->atom == dummyAtom;
+            return propertyNotify->window == window && propertyNotify->atom == dummyAtom &&
+                propertyNotify->state == 0;
         });
     }
 


### PR DESCRIPTION
`PropertyNotify` event generated by `xcb_delete_property()` at return have to be ignored otherwise the timestamp of that event from a previous call might be reported.

This issue was reported in QTBUG-56595 but was not addressed at that time. It causes observable problems in kwin_x11 (KDE project).