### PR TITLE
Backport patch from upstream valgrind to fix build with clang:

### DIFF
--- a/src/testlib/3rdparty/valgrind_p.h
+++ b/src/testlib/3rdparty/valgrind_p.h
@@ -872,7 +872,8 @@ typedef
                     /* results = r3 */                           \
                     "lgr %0, 3\n\t"                              \
                     : "=d" (_zzq_result)                         \
-                    : "a" (&_zzq_args[0]), "0" (_zzq_default)    \
+                    : "a" (&_zzq_args[0]),                       \
+                      "0" ((unsigned long int)_zzq_default)      \
                     : "cc", "2", "3", "memory"                   \
                    );                                            \
    _zzq_result;                                                  \


### PR DESCRIPTION
Bug 430429 - s390x: Fix clang compile error in valgrind.h

It has been observed that clang emits an error in valgrind.h for the macro VALGRIND_DO_CLIENT_REQUEST_EXPR:

 "[...] unsupported inline asm: input with type 'int' matching output with
 type 'volatile unsigned long'"

Fix this with an explicit cast of the input to 'unsigned long int.'

The patch has been suggested by Jonathan Albrecht.