### PR TITLE
QDBusContext: add single parameter overload for sendErrorReply

### DIFF
--- a/src/dbus/qdbuscontext.cpp
+++ b/src/dbus/qdbuscontext.cpp
@@ -165,6 +165,19 @@ void QDBusContext::sendErrorReply(QDBusError::ErrorType type, const QString &msg
     connection().send(message().createErrorReply(type, msg));
 }
 
+/*!
+    \overload
+    Sends an error \a err as a reply to the caller.
+
+    If an error is sent, the return value and any output parameters
+    from the called slot will be ignored by Qt D-Bus.
+*/
+void QDBusContext::sendErrorReply(const QDBusError &err) const
+{
+    setDelayedReply(true);
+    connection().send(message().createError(err));
+}
+
 QT_END_NAMESPACE
 
 #endif // QT_NO_DBUS

--- a/src/dbus/qdbuscontext.h
+++ b/src/dbus/qdbuscontext.h
@@ -33,6 +33,7 @@ public:
     void setDelayedReply(bool enable) const;
     void sendErrorReply(const QString &name, const QString &msg = QString()) const;
     void sendErrorReply(QDBusError::ErrorType type, const QString &msg = QString()) const;
+    void sendErrorReply(const QDBusError &err) const;
 
 private:
     QDBusContextPrivate *d_ptr;


### PR DESCRIPTION
This new method allows creating and storing exact error replies in a single variable, then passing the error to the object that is subclassing QDBusContext.