### PR TITLE
Fixed assertion in endframe (d3d11 backend)

### DIFF
--- a/src/gui/rhi/qrhid3d11.cpp
+++ b/src/gui/rhi/qrhid3d11.cpp
@@ -1267,7 +1267,7 @@ QRhi::FrameOpResult QRhiD3D11::beginFrame(QRhiSwapChain *swapChain, QRhi::BeginF
 QRhi::FrameOpResult QRhiD3D11::endFrame(QRhiSwapChain *swapChain, QRhi::EndFrameFlags flags)
 {
     QD3D11SwapChain *swapChainD = QRHI_RES(QD3D11SwapChain, swapChain);
-    Q_ASSERT(contextState.currentSwapChain = swapChainD);
+    Q_ASSERT(contextState.currentSwapChain == swapChainD);
     const int currentFrameSlot = swapChainD->currentFrameSlot;
 
     ID3D11Query *tsDisjoint = swapChainD->timestampDisjointQuery[currentFrameSlot];


### PR DESCRIPTION
Fixed assertion:
The other backends all check that both instances of the given swapchains are the same. However, for the D3D11 backend, an assignment is being asserted.