### PR TITLE
Drag & Drop wrong result DropAction when using QGraphicsProxyWidget

### DIFF
--- a/src/widgets/graphicsview/qgraphicsproxywidget.cpp
+++ b/src/widgets/graphicsview/qgraphicsproxywidget.cpp
@@ -1134,7 +1134,11 @@ void QGraphicsProxyWidget::dropEvent(QGraphicsSceneDragDropEvent *event)
         QPoint widgetPos = d->mapToReceiver(event->pos(), d->dragDropWidget).toPoint();
         QDropEvent dropEvent(widgetPos, event->possibleActions(), event->mimeData(), event->buttons(), event->modifiers());
         QCoreApplication::sendEvent(d->dragDropWidget, &dropEvent);
-        event->setAccepted(dropEvent.isAccepted());
+        const bool accepted = dropEvent.isAccepted();
+        event->setAccepted(accepted);
+        if(accepted){
+            event->setDropAction(dropEvent.dropAction());
+        }
         d->dragDropWidget = nullptr;
     }
 #endif


### PR DESCRIPTION
QGraphicsSceneDragDropEvent didn't call setDropAction() when accepted, which makes it impossible to get correct QDrag::exec() return value.