### PR TITLE
Use windows sytle screen name

### DIFF
--- a/src/plugins/platforms/windows/qwindowsscreen.cpp
+++ b/src/plugins/platforms/windows/qwindowsscreen.cpp
@@ -344,16 +344,7 @@ BOOL QT_WIN_CALLBACK monitorEnumCallback(HMONITOR hMonitor, HDC, LPRECT, LPARAM 
     QWindowsScreenData data;
     if (monitorData(hMonitor, &data)) {
         auto *result = reinterpret_cast<WindowsScreenDataList *>(p);
-        auto it = std::find_if(result->rbegin(), result->rend(),
-            [&data](QWindowsScreenData i){ return i.name == data.name; });
-        if (it != result->rend()) {
-            int previousIndex = 1;
-            if (it->deviceIndex.has_value())
-                previousIndex = it->deviceIndex.value();
-            else
-                (*it).deviceIndex = 1;
-            data.deviceIndex = previousIndex + 1;
-        }
+
         // QWindowSystemInterface::handleScreenAdded() documentation specifies that first
         // added screen will be the primary screen, so order accordingly.
         // Note that the side effect of this policy is that there is no way to change primary
@@ -415,9 +406,7 @@ QWindowsScreen::QWindowsScreen(const QWindowsScreenData &data) :
 
 QString QWindowsScreen::name() const
 {
-    return m_data.deviceIndex.has_value()
-               ? (u"%1 (%2)"_s).arg(m_data.name, QString::number(m_data.deviceIndex.value()))
-               : m_data.name;
+    return m_data.name;
 }
 
 QPixmap QWindowsScreen::grabWindow(WId window, int xIn, int yIn, int width, int height) const

--- a/src/plugins/platforms/windows/qwindowsscreen.cpp
+++ b/src/plugins/platforms/windows/qwindowsscreen.cpp
@@ -277,7 +277,9 @@ static bool monitorData(HMONITOR hMonitor, QWindowsScreenData *data)
         setMonitorDataFromSetupApi(*data, pathGroup);
     }
     if (data->name.isEmpty())
-        data->name = data->deviceName;
+        data->name.append(u"Internal Display");
+    data->name.prepend(u": ");
+    data->name.prepend(data->deviceName);
     if (data->deviceName == u"WinDisc") {
         data->flags |= QWindowsScreenData::LockScreen;
     } else {

--- a/src/plugins/platforms/windows/qwindowsscreen.h
+++ b/src/plugins/platforms/windows/qwindowsscreen.h
@@ -38,7 +38,6 @@ struct QWindowsScreenData
     HMONITOR hMonitor = nullptr;
     QString deviceName;
     QString devicePath;
-    std::optional<int> deviceIndex = std::nullopt;
 };
 
 class QWindowsScreen : public QPlatformScreen, public QNativeInterface::QWindowsScreen


### PR DESCRIPTION
Screen name on widows shows like `DELL XXX` doesn't tells its device name, if there are two identical screens connected, it shows DELL XXX and DELL XXX 1 which is not `friendly`. For windows display settings, you can see that it writes like `Display1: DELL XXX` and `Display 2: DELL XXX`.
This change adds `Display X:` before would indicate current device name and remove unused device index variables.