### PR TITLE
Eliminate a potential bug

### DIFF
--- a/src/corelib/kernel/qeventdispatcher_glib.cpp
+++ b/src/corelib/kernel/qeventdispatcher_glib.cpp
@@ -68,9 +68,11 @@ static gboolean socketNotifierSourceDispatch(GSource *source, GSourceFunc, gpoin
     QEvent event(QEvent::SockAct);
 
     GSocketNotifierSource *src = reinterpret_cast<GSocketNotifierSource *>(source);
-    for (src->activeNotifierPos = 0; src->activeNotifierPos < src->pollfds.size();
-         ++src->activeNotifierPos) {
+    src->activeNotifierPos = 0;
+    while (src->activeNotifierPos < src->pollfds.size()) {
         GPollFDWithQSocketNotifier *p = src->pollfds.at(src->activeNotifierPos);
+
+        ++src->activeNotifierPos;
 
         if ((p->pollfd.revents & p->pollfd.events) != 0)
             QCoreApplication::sendEvent(p->socketNotifier, &event);


### PR DESCRIPTION
If we send an event here, we may enter a new event loop and then the new event loop will process the events including socket events. As a result, after exiting the new event loop, the activeNotifierPos is same as the src->pollfds.count() and activeNotifierPos will be added by one in the old event loop.

So there is a potential situation that activeNotifierPos will overflow if we have too many sockets and nested event loops.

Although this situation is almost impossible, we can improve the code by little effort. That's it.