### PR TITLE
Changed `cache.empty()` to `cache.clear()`

### DIFF
--- a/src/sql/models/qsqltablemodel.cpp
+++ b/src/sql/models/qsqltablemodel.cpp
@@ -1109,7 +1109,7 @@ bool QSqlTableModel::insertRows(int row, int count, const QModelIndex &parent)
     beginInsertRows(parent, row, row + count - 1);
 
     if (d->strategy != OnManualSubmit)
-        d->cache.empty();
+        d->cache.clear();
 
     if (!d->cache.isEmpty()) {
         QMap<int, QSqlTableModelPrivate::ModifiedRow>::Iterator it = d->cache.end();


### PR DESCRIPTION
The call to the const `empty()` didn't do anything, because its results were unused. I think the original intention was to make it empty aka to clear it. (Or if we need not modify it we should remove the whole `if` statement and the `empty()` call in it)