### PR TITLE
Variable template specialization must be explicitly 'inline'

### DIFF
--- a/src/corelib/global/qcomparehelpers.h
+++ b/src/corelib/global/qcomparehelpers.h
@@ -774,7 +774,7 @@ constexpr bool IsFloatType_v = std::is_floating_point_v<T>;
 
 #if QFLOAT16_IS_NATIVE
 template <>
-constexpr bool IsFloatType_v<QtPrivate::NativeFloat16Type> = true;
+constexpr inline bool IsFloatType_v<QtPrivate::NativeFloat16Type> = true;
 #endif
 
 } // namespace QtPrivate


### PR DESCRIPTION
...or else there would be multiple definitions of it across TUs.  (With GCC, this only hit since
<https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=82cd63a63eaa61a4ed5c4029a1869be7446ecb3c> " c++: Implement CWG2387 - Linkage of const-qualified variable template [PR109126]".  With Clang, it never hit because QFLOAT16_IS_NATIVE is explicitly disabled for Clang in qtypes.h.)