### PR TITLE
Security Vulnerability - Action Required: heap-based buffer overflow vulnerability may in your project

### DIFF
--- a/src/3rdparty/libjpeg/src/jdlossls.c
+++ b/src/3rdparty/libjpeg/src/jdlossls.c
@@ -216,8 +216,16 @@ METHODDEF(void)
 simple_upscale(j_decompress_ptr cinfo,
                JDIFFROW diff_buf, _JSAMPROW output_buf, JDIMENSION width)
 {
-  do {
+   do {
+#if BITS_IN_JSAMPLE == 12
+    /* 12-bit is the only data precision for which the range of the sample data
+     * type exceeds the valid sample range.  Thus, we need to range-limit the
+     * samples, because other algorithms may try to use them as array indices.
+     */
+    *output_buf++ = (_JSAMPLE)((*diff_buf++ << cinfo->Al) & 0xFFF);
+#else
     *output_buf++ = (_JSAMPLE)(*diff_buf++ << cinfo->Al);
+#endif
   } while (--width);
 }
 
@@ -226,7 +234,11 @@ noscale(j_decompress_ptr cinfo,
         JDIFFROW diff_buf, _JSAMPROW output_buf, JDIMENSION width)
 {
   do {
+#if BITS_IN_JSAMPLE == 12
+    *output_buf++ = (_JSAMPLE)((*diff_buf++) & 0xFFF);
+#else
     *output_buf++ = (_JSAMPLE)(*diff_buf++);
+#endif
   } while (--width);
 }
 


### PR DESCRIPTION
Hi,
   we have detected that your project may be vulnerable to heap-based buffer overflow in the function of `simple_upscale` in the file of `src/3rdparty/libjpeg/src/jdlossls.c` . It shares similarities to a recent CVE disclosure https://nvd.nist.gov/vuln/detail/CVE-2023-2804 in the https://github.com/libjpeg-turbo/libjpeg-turbo.

**The source vulnerability information is as follows:**

> Vulnerability Detail:
> CVE Identifier: CVE-2023-2804
> Description: A heap-based buffer overflow issue was discovered in libjpeg-turbo in h2v2_merged_upsample_internal() function of jdmrgext.c file. The vulnerability can only be exploited with 12-bit data precision for which the range of the sample data type exceeds the valid sample range, hence, an attacker could craft a 12-bit lossless JPEG image that contains out-of-range 12-bit samples. An application attempting to decompress such image using merged upsampling would lead to segmentation fault or buffer overflows, causing an application to crash.
> Reference:https://nvd.nist.gov/vuln/detail/CVE-2023-2804
> Patch: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/9f756bc67a84d4566bf74a0c2432aa55da404021

Would you help to check if this bug is true? If it's true, please review this pr. Thank you for your effort and patience! 
