### PR TITLE
Docs: add information about unfocused windows to TuioTouch README

### DIFF
--- a/src/plugins/generic/tuiotouch/README.md
+++ b/src/plugins/generic/tuiotouch/README.md
@@ -45,6 +45,9 @@ You can also rotate the coordinates directly, using the rotate option:
 
 Supported rotations are 90, 180, and 270.
 
+If you need to receive touch events while the window is not in focus, make sure
+that the QT_TUIOTOUCH_DELIVER_WITHOUT_FOCUS environment variable is set.
+
 ## Further work
 
 * Support other profiles (we implement 2Dcur, we want 2Dobj, 2Dblb?)


### PR DESCRIPTION
I had some issues getting the TuioTouch plugin to work, as my sending application would take focus over my receiving QtQuick application. I try to prevent this issue in the future for other users, by adding a small hint to the README of the plugin.