### PR TITLE
Improve performance of QTabWidget::clear

### DIFF
--- a/src/widgets/widgets/qtabwidget.cpp
+++ b/src/widgets/widgets/qtabwidget.cpp
@@ -1403,8 +1403,8 @@ void QTabWidget::setTabBarAutoHide(bool enabled)
 void QTabWidget::clear()
 {
     // ### optimize by introduce QStackedLayout::clear()
-    while (count())
-        removeTab(0);
+    while (const int count = count())
+        removeTab(count - 1);
 }
 
 QTabBar::Shape _q_tb_tabBarShapeFrom(QTabWidget::TabShape shape, QTabWidget::TabPosition position)


### PR DESCRIPTION
The current implementation of _QTabWidget::clear_ is quite poor because it deletes the tabs from first to last. When I was playing around, I found out it's much faster to delete from last to first (with a lot of tabs it goes from two seconds to 200 milliseconds in my testing). I assume this has to do with the redrawing of all remaining tabs for each _removeTab_ call, while this is not necessary when removing in the reverse order.