### PR TITLE
Update the check for WebAssembly JSPI support

### DIFF
--- a/src/corelib/platform/wasm/qstdweb.cpp
+++ b/src/corelib/platform/wasm/qstdweb.cpp
@@ -365,7 +365,7 @@ void WebPromiseManager::adoptPromise(emscripten::val target, PromiseCallbacks ca
 
 EM_JS(bool, jsHaveAsyncify, (), { return typeof Asyncify !== "undefined"; });
 EM_JS(bool, jsHaveJspi, (),
-      { return typeof Asyncify !== "undefined" && !!Asyncify.makeAsyncFunction && !!WebAssembly.Function; });
+      { return typeof Asyncify !== "undefined" && !!Asyncify.makeAsyncFunction && (!!WebAssembly.Function || !!WebAssembly.Suspending); });
 
 #else
 


### PR DESCRIPTION
At least Chrome 130 (after explicitly enabling "Experimental WebAssembly JavaScript Promise Integration (JSPI)" in <chrome://flags/>) no longer has WebAssembly.Function, but has WebAssembly.Suspending.  Which appears to be in line with what is documented in the 2024-06-04 post at <https://v8.dev/blog/jspi-newapi> "WebAssembly JSPI has a new API".