### PR TITLE
Fixes mistypes in sql warning messages

### DIFF
--- a/src/corelib/doc/snippets/code/src_corelib_global_qglobal.cpp
+++ b/src/corelib/doc/snippets/code/src_corelib_global_qglobal.cpp
@@ -34,7 +34,7 @@ typedef QFlags<Enum> Flags;
 
 //! [4]
 if (!driver()->isOpen() || driver()->isOpenError()) {
-    qWarning("QSqlQuery::exec: database not open");
+    qWarning("QSqlQuery::exec: database is not open");
     return false;
 }
 //! [4]

--- a/src/plugins/sqldrivers/db2/qsql_db2.cpp
+++ b/src/plugins/sqldrivers/db2/qsql_db2.cpp
@@ -1584,7 +1584,7 @@ bool QDB2Driver::hasFeature(DriverFeature f) const
 bool QDB2Driver::beginTransaction()
 {
     if (!isOpen()) {
-        qWarning("QDB2Driver::beginTransaction: Database not open");
+        qWarning("QDB2Driver::beginTransaction: Database is not open");
         return false;
     }
     return setAutoCommit(false);
@@ -1594,7 +1594,7 @@ bool QDB2Driver::commitTransaction()
 {
     Q_D(QDB2Driver);
     if (!isOpen()) {
-        qWarning("QDB2Driver::commitTransaction: Database not open");
+        qWarning("QDB2Driver::commitTransaction: Database is not open");
         return false;
     }
     SQLRETURN r = SQLEndTran(SQL_HANDLE_DBC,
@@ -1612,7 +1612,7 @@ bool QDB2Driver::rollbackTransaction()
 {
     Q_D(QDB2Driver);
     if (!isOpen()) {
-        qWarning("QDB2Driver::rollbackTransaction: Database not open");
+        qWarning("QDB2Driver::rollbackTransaction: Database is not open");
         return false;
     }
     SQLRETURN r = SQLEndTran(SQL_HANDLE_DBC,

--- a/src/plugins/sqldrivers/ibase/qsql_ibase.cpp
+++ b/src/plugins/sqldrivers/ibase/qsql_ibase.cpp
@@ -1890,7 +1890,7 @@ bool QIBaseDriver::subscribeToNotification(const QString &name)
 {
     Q_D(QIBaseDriver);
     if (!isOpen()) {
-        qCWarning(lcIbase, "QIBaseDriver::subscribeFromNotificationImplementation: database not open.");
+        qCWarning(lcIbase, "QIBaseDriver::subscribeFromNotificationImplementation: database is not open.");
         return false;
     }
 
@@ -1937,7 +1937,7 @@ bool QIBaseDriver::unsubscribeFromNotification(const QString &name)
 {
     Q_D(QIBaseDriver);
     if (!isOpen()) {
-        qCWarning(lcIbase, "QIBaseDriver::unsubscribeFromNotificationImplementation: database not open.");
+        qCWarning(lcIbase, "QIBaseDriver::unsubscribeFromNotificationImplementation: database is not open.");
         return false;
     }
 

--- a/src/plugins/sqldrivers/mysql/qsql_mysql.cpp
+++ b/src/plugins/sqldrivers/mysql/qsql_mysql.cpp
@@ -1543,7 +1543,7 @@ bool QMYSQLDriver::beginTransaction()
 {
     Q_D(QMYSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcMysql, "QMYSQLDriver::beginTransaction: Database not open");
+        qCWarning(lcMysql, "QMYSQLDriver::beginTransaction: Database is not open");
         return false;
     }
     if (mysql_query(d->mysql, "BEGIN WORK")) {
@@ -1558,7 +1558,7 @@ bool QMYSQLDriver::commitTransaction()
 {
     Q_D(QMYSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcMysql, "QMYSQLDriver::commitTransaction: Database not open");
+        qCWarning(lcMysql, "QMYSQLDriver::commitTransaction: Database is not open");
         return false;
     }
     if (mysql_query(d->mysql, "COMMIT")) {
@@ -1573,7 +1573,7 @@ bool QMYSQLDriver::rollbackTransaction()
 {
     Q_D(QMYSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcMysql, "QMYSQLDriver::rollbackTransaction: Database not open");
+        qCWarning(lcMysql, "QMYSQLDriver::rollbackTransaction: Database is not open");
         return false;
     }
     if (mysql_query(d->mysql, "ROLLBACK")) {
@@ -1610,7 +1610,7 @@ QString QMYSQLDriver::formatValue(const QSqlField &field, bool trimStrings) cons
                 r = u'\'' + QString::fromUtf8(buffer.data(), escapedSize) + u'\'';
                 break;
             } else {
-                qCWarning(lcMysql, "QMYSQLDriver::formatValue: Database not open");
+                qCWarning(lcMysql, "QMYSQLDriver::formatValue: Database is not open");
             }
             Q_FALLTHROUGH();
         case QMetaType::QDateTime:

--- a/src/plugins/sqldrivers/oci/qsql_oci.cpp
+++ b/src/plugins/sqldrivers/oci/qsql_oci.cpp
@@ -2354,7 +2354,7 @@ bool QOCIDriver::beginTransaction()
 {
     Q_D(QOCIDriver);
     if (!isOpen()) {
-        qCWarning(lcOci, "QOCIDriver::beginTransaction: Database not open");
+        qCWarning(lcOci, "QOCIDriver::beginTransaction: Database is not open");
         return false;
     }
     int r = OCITransStart(d->svc,
@@ -2375,7 +2375,7 @@ bool QOCIDriver::commitTransaction()
 {
     Q_D(QOCIDriver);
     if (!isOpen()) {
-        qCWarning(lcOci, "QOCIDriver::commitTransaction: Database not open");
+        qCWarning(lcOci, "QOCIDriver::commitTransaction: Database is not open");
         return false;
     }
     int r = OCITransCommit(d->svc,
@@ -2395,7 +2395,7 @@ bool QOCIDriver::rollbackTransaction()
 {
     Q_D(QOCIDriver);
     if (!isOpen()) {
-        qCWarning(lcOci, "QOCIDriver::rollbackTransaction: Database not open");
+        qCWarning(lcOci, "QOCIDriver::rollbackTransaction: Database is not open");
         return false;
     }
     int r = OCITransRollback(d->svc,

--- a/src/plugins/sqldrivers/odbc/qsql_odbc.cpp
+++ b/src/plugins/sqldrivers/odbc/qsql_odbc.cpp
@@ -2280,7 +2280,7 @@ bool QODBCDriver::beginTransaction()
 {
     Q_D(QODBCDriver);
     if (!isOpen()) {
-        qSqlWarning("QODBCDriver::beginTransaction: Database not open"_L1, d);
+        qSqlWarning("QODBCDriver::beginTransaction: Database is not open"_L1, d);
         return false;
     }
     SQLUINTEGER ac(SQL_AUTOCOMMIT_OFF);
@@ -2300,7 +2300,7 @@ bool QODBCDriver::commitTransaction()
 {
     Q_D(QODBCDriver);
     if (!isOpen()) {
-        qSqlWarning("QODBCDriver::commitTransaction: Database not open"_L1, d);
+        qSqlWarning("QODBCDriver::commitTransaction: Database is not open"_L1, d);
         return false;
     }
     SQLRETURN r = SQLEndTran(SQL_HANDLE_DBC,
@@ -2318,7 +2318,7 @@ bool QODBCDriver::rollbackTransaction()
 {
     Q_D(QODBCDriver);
     if (!isOpen()) {
-        qSqlWarning("QODBCDriver::rollbackTransaction: Database not open"_L1, d);
+        qSqlWarning("QODBCDriver::rollbackTransaction: Database is not open"_L1, d);
         return false;
     }
     SQLRETURN r = SQLEndTran(SQL_HANDLE_DBC,

--- a/src/plugins/sqldrivers/psql/qsql_psql.cpp
+++ b/src/plugins/sqldrivers/psql/qsql_psql.cpp
@@ -1243,7 +1243,7 @@ bool QPSQLDriver::beginTransaction()
 {
     Q_D(QPSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcPsql, "QPSQLDriver::beginTransaction: Database not open.");
+        qCWarning(lcPsql, "QPSQLDriver::beginTransaction: Database is not open.");
         return false;
     }
     PGresult *res = d->exec("BEGIN");
@@ -1261,7 +1261,7 @@ bool QPSQLDriver::commitTransaction()
 {
     Q_D(QPSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcPsql, "QPSQLDriver::commitTransaction: Database not open.");
+        qCWarning(lcPsql, "QPSQLDriver::commitTransaction: Database is not open.");
         return false;
     }
     PGresult *res = d->exec("COMMIT");
@@ -1290,7 +1290,7 @@ bool QPSQLDriver::rollbackTransaction()
 {
     Q_D(QPSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcPsql, "QPSQLDriver::rollbackTransaction: Database not open.");
+        qCWarning(lcPsql, "QPSQLDriver::rollbackTransaction: Database is not open.");
         return false;
     }
     PGresult *res = d->exec("ROLLBACK");
@@ -1545,7 +1545,7 @@ bool QPSQLDriver::subscribeToNotification(const QString &name)
 {
     Q_D(QPSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcPsql, "QPSQLDriver::subscribeToNotification: Database not open.");
+        qCWarning(lcPsql, "QPSQLDriver::subscribeToNotification: Database is not open.");
         return false;
     }
 
@@ -1586,7 +1586,7 @@ bool QPSQLDriver::unsubscribeFromNotification(const QString &name)
 {
     Q_D(QPSQLDriver);
     if (!isOpen()) {
-        qCWarning(lcPsql, "QPSQLDriver::unsubscribeFromNotification: Database not open.");
+        qCWarning(lcPsql, "QPSQLDriver::unsubscribeFromNotification: Database is not open.");
         return false;
     }
 

--- a/src/plugins/sqldrivers/sqlite/qsql_sqlite.cpp
+++ b/src/plugins/sqldrivers/sqlite/qsql_sqlite.cpp
@@ -1058,7 +1058,7 @@ bool QSQLiteDriver::subscribeToNotification(const QString &name)
 {
     Q_D(QSQLiteDriver);
     if (!isOpen()) {
-        qCWarning(lcSqlite, "QSQLiteDriver::subscribeToNotification: Database not open.");
+        qCWarning(lcSqlite, "QSQLiteDriver::subscribeToNotification: Database is not open.");
         return false;
     }
 
@@ -1080,7 +1080,7 @@ bool QSQLiteDriver::unsubscribeFromNotification(const QString &name)
 {
     Q_D(QSQLiteDriver);
     if (!isOpen()) {
-        qCWarning(lcSqlite, "QSQLiteDriver::unsubscribeFromNotification: Database not open.");
+        qCWarning(lcSqlite, "QSQLiteDriver::unsubscribeFromNotification: Database is not open.");
         return false;
     }
 

--- a/src/sql/kernel/qsqlquery.cpp
+++ b/src/sql/kernel/qsqlquery.cpp
@@ -396,7 +396,7 @@ bool QSqlQuery::exec(const QString& query)
     }
     d->sqlResult->setQuery(query.trimmed());
     if (!driver()->isOpen() || driver()->isOpenError()) {
-        qCWarning(lcSqlQuery, "QSqlQuery::exec: database not open");
+        qCWarning(lcSqlQuery, "QSqlQuery::exec: database is not open");
         return false;
     }
     if (query.isEmpty()) {
@@ -993,7 +993,7 @@ bool QSqlQuery::prepare(const QString& query)
         return false;
     }
     if (!driver()->isOpen() || driver()->isOpenError()) {
-        qCWarning(lcSqlQuery, "QSqlQuery::prepare: database not open");
+        qCWarning(lcSqlQuery, "QSqlQuery::prepare: database is not open");
         return false;
     }
     if (query.isEmpty()) {

--- a/tests/auto/sql/kernel/qsqlquery/tst_qsqlquery.cpp
+++ b/tests/auto/sql/kernel/qsqlquery/tst_qsqlquery.cpp
@@ -2916,14 +2916,14 @@ void tst_QSqlQuery::queryOnInvalidDatabase()
         QSqlDatabase db = QSqlDatabase::addDatabase("INVALID", "invalidConnection");
         QVERIFY(db.lastError().isValid());
 
-        QTest::ignoreMessage(QtWarningMsg, "QSqlQuery::exec: database not open");
+        QTest::ignoreMessage(QtWarningMsg, "QSqlQuery::exec: database is not open");
         QSqlQuery query("SELECT 1 AS ID", db);
         QVERIFY(query.lastError().isValid());
     }
 
     {
         QSqlDatabase db = QSqlDatabase::database("this connection does not exist");
-        QTest::ignoreMessage(QtWarningMsg, "QSqlQuery::exec: database not open");
+        QTest::ignoreMessage(QtWarningMsg, "QSqlQuery::exec: database is not open");
         QSqlQuery query("SELECT 1 AS ID", db);
         QVERIFY(query.lastError().isValid());
     }


### PR DESCRIPTION
Case preserved

You check it before with IsOpen() call, thus !isOpen() == IS NOT open