### PR TITLE
Extended QSharedPointer and QWeakPointer with isShared and needsDetach

### DIFF
--- a/src/corelib/tools/qsharedpointer_impl.h
+++ b/src/corelib/tools/qsharedpointer_impl.h
@@ -114,6 +114,14 @@ namespace QtSharedPointer {
 
         void destroy() { destroyer(this); }
 
+        bool isShared() const noexcept {
+            return strongref.loadRelaxed() != 1;
+        }
+
+        bool needsDetach() const noexcept {
+            return strongref.loadRelaxed() > 1;
+        }
+
 #ifndef QT_NO_QOBJECT
         Q_CORE_EXPORT static ExternalRefCountData *getAndRef(const QObject *);
         QT6_ONLY(
@@ -463,6 +471,11 @@ public:
     size_t owner_hash() const noexcept
     { return std::hash<Data *>()(d); }
 
+    bool isShared() const noexcept
+    { return !d || d->isShared(); }
+    bool needsDetach() const noexcept
+    { return !d || d->needsDetach(); }
+
 private:
     Q_NODISCARD_CTOR
     explicit QSharedPointer(Qt::Initialization) {}
@@ -716,6 +729,11 @@ public:
 
     size_t owner_hash() const noexcept
     { return std::hash<Data *>()(d); }
+
+    bool isShared() const noexcept
+    { return !d || d->isShared(); }
+    bool needsDetach() const noexcept
+    { return !d || d->needsDetach(); }
 
 private:
     friend struct QtPrivate::EnableInternalData;


### PR DESCRIPTION
This is like it is used in QArrayDataPointer and allows to evaluate if cloning of an object is needed when it must to be changed without affecting other references. This functionality was available in Qt 5 via direct access to the ref count.