### PR TITLE
QEvent: Checking for valid device before accessing during formatTouch…

### DIFF
--- a/src/gui/kernel/qevent.cpp
+++ b/src/gui/kernel/qevent.cpp
@@ -3754,7 +3754,8 @@ static inline void formatTouchEvent(QDebug d, const QTouchEvent &t)
 {
     d << "QTouchEvent(";
     QtDebugUtils::formatQEnum(d, t.type());
-    d << " device: " << t.device()->name();
+    const auto* device = t.device();
+    d << " device: " << device ? device->name() : "No device";
     d << " states: ";
     QtDebugUtils::formatQFlags(d, t.touchPointStates());
     d << ", " << t.points().size() << " points: " << t.points() << ')';


### PR DESCRIPTION
Added check for `nullptr`  device() before accessing device name. Using "No device" for the device name when there is no device set.

To reproduce:
```
QTouchEvent t(QEvent::Type::TouchBegin);
qDebug() << &t;
```