### PR TITLE
Update qstring.cpp

### DIFF
--- a/src/corelib/text/qstring.cpp
+++ b/src/corelib/text/qstring.cpp
@@ -9538,7 +9538,7 @@ QDataStream &operator>>(QDataStream &in, QString &str)
             qsizetype allocated = 0;
 
             while (allocated < len) {
-                int blockSize = qMin(Step, len - allocated);
+                qsizetype blockSize = qMin(Step, len - allocated);
                 str.resize(allocated + blockSize);
                 if (in.readRawData(reinterpret_cast<char *>(str.data()) + allocated * 2,
                                    blockSize * 2) != blockSize * 2) {


### PR DESCRIPTION
Set blockSize type to qsizetype.

All variables in evaluation of this value are qsizetype. So it's not a good idea to make it int even if we know that its size is in certain range. Moreover, its size can differ on different platforms.

It can also lead to the problems with overflow a few lines below, where multiplication by 2 takes place.