### PR TITLE
Fix inaccurate usleep duration in QThread on Windows

### DIFF
--- a/src/corelib/thread/qthread_win.cpp
+++ b/src/corelib/thread/qthread_win.cpp
@@ -311,7 +311,7 @@ void QThread::msleep(unsigned long msecs)
 
 void QThread::usleep(unsigned long usecs)
 {
-    ::Sleep((usecs / 1000) + 1);
+    ::Sleep((usecs + 999) / 1000);
 }
 
 #if QT_CONFIG(thread)


### PR DESCRIPTION
Replace (usec/1000)+1 with (usec+999)/1000 to ensure correct millisecond conversion for small values. 
Previously, passing 1000 would incorrectly sleep for 2ms instead of 1ms.